### PR TITLE
OESE-178 - update docker and test to word press 5.7

### DIFF
--- a/docker/oese.dockerfile
+++ b/docker/oese.dockerfile
@@ -1,5 +1,5 @@
 # change the below tag to whatever (reasonable) combination of WP and PHP version you need
-FROM wordpress:4.9.15-php7.2
+FROM wordpress:5.7.2-php7.3
 RUN apt-get update
 RUN apt-get install -y nano vim mysql-client
 # we have our own copy, the WP setup will overwrite it if it isn't removed from the src

--- a/docker/server-oese.dockerfile
+++ b/docker/server-oese.dockerfile
@@ -1,5 +1,5 @@
 # change the below tag to whatever (reasonable) combination of WP and PHP version you need
-FROM wordpress:5.7.2-php7.4
+FROM wordpress:5.7.2-php7.3
 RUN apt-get update
 RUN apt-get install -y nano vim default-mysql-client
 RUN cd /usr/local/bin ; curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar ; chmod +x wp-cli.phar ; mv wp-cli.phar wp


### PR DESCRIPTION
- Updated local docker file to use WP5.7.2-php7.3
- Server docker file is already running WP5.7.2-php7.4, so I've downgraded the php to php7.3 as instructed in this task.